### PR TITLE
[dpdk-rs] Enhancement: Providing the rte_pktmbuf_prepend for Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -294,6 +294,7 @@ fn os_build() -> Result<()> {
         .allowlist_function("rte_eth_tx_burst")
         .allowlist_function("rte_eth_rx_burst")
         .allowlist_function("rte_eal_init")
+        .allowlist_function("rte_pktmbuf_prepend")
         .clang_arg("-mavx")
         .header("wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/inlined.c
+++ b/inlined.c
@@ -97,3 +97,8 @@ int rte_eth_tx_offload_multi_segs_()
 {
     return RTE_ETH_TX_OFFLOAD_MULTI_SEGS;
 }
+
+char *rte_pktmbuf_prepend_(struct rte_mbuf *m, uint16_t len)
+{
+    return rte_pktmbuf_prepend(m, len);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern "C" {
     fn rte_eth_rx_offload_tcp_cksum_() -> c_int;
     fn rte_eth_rx_offload_udp_cksum_() -> c_int;
     fn rte_eth_tx_offload_multi_segs_() -> c_int;
+    fn rte_pktmbuf_prepend_(m: *mut rte_mbuf, len: u16) -> *mut c_char;
 }
 
 #[cfg(all(feature = "mlx5", target_os = "windows"))]
@@ -149,4 +150,9 @@ pub unsafe fn rte_eth_rx_offload_udp_cksum() -> c_int {
 #[inline]
 pub unsafe fn rte_eth_tx_offload_multi_segs() -> c_int {
     rte_eth_tx_offload_multi_segs_()
+}
+
+#[inline]
+pub unsafe fn rte_pktmbuf_prepend(m: *mut rte_mbuf, len: u16) -> *mut c_char {
+    rte_pktmbuf_prepend_(m, len)
 }


### PR DESCRIPTION
### Description
- This PR provides the `rte_pktmbuf_prepend` function for Linux to be used on the Catnip of the Demikernel

### Summary of Changes
- Added the `rte_pktmbuf_prepend` into build.rs, inlined.c, and src/lib.rs files.