### PR TITLE
Add missing linkage declaration to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 homepage = "https://aka.ms/demikernel"
 repository = "https://github.com/demikernel/dpdk-rs"
 license-file = "LICENSE.txt"
+links = "dpdk"
 
 [dependencies]
 cfg-if = "1.0.0"


### PR DESCRIPTION
Per rust documentation (https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key), a crate which links with a native C library is supposed to declare that using the "links" manifest key in order to avoid linking two copies of a native library. Some third-party sites also use this field to aid in searching for rust bindings to native libraries.