### PR TITLE
[dpdk-rs] [Enhancement for build system] Switch to rust foundation pkg config library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 homepage = "https://aka.ms/demikernel"
 repository = "https://github.com/demikernel/dpdk-rs"
 license-file = "LICENSE.txt"
+links = "dpdk"
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -19,8 +20,14 @@ cfg-if = "1.0.0"
 anyhow = "1.0.62"
 bindgen = "0.60.1"
 cc = "1.0.73"
+ya-pkg-config = "0.0.1"
 
 [features]
+default = ["static_dpdk", "static_stub"]
+# Statically link DPDK.
+static_dpdk = []
+# Statically link the stub file used for inline functions.
+static_stub = []
 mlx4 = []
 mlx5 = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,9 @@ cfg-if = "1.0.0"
 anyhow = "1.0.62"
 bindgen = "0.60.1"
 cc = "1.0.73"
-ya-pkg-config = "0.0.1"
+pkg-config = "0.3.27"
 
 [features]
-default = ["static_dpdk", "static_stub"]
-# Statically link DPDK.
-static_dpdk = []
-# Statically link the stub file used for inline functions.
-static_stub = []
 mlx4 = []
 mlx5 = []
 

--- a/build.rs
+++ b/build.rs
@@ -167,66 +167,96 @@ fn os_build() -> Result<()> {
 
 #[cfg(target_os = "linux")]
 fn os_build() -> Result<()> {
-    use ::std::process::Command;
+    let mut libdpdk_pkg_config = ::ya_pkg_config::Config::new();
+    libdpdk_pkg_config
+        // .statik(cfg!(static_dpdk))
+        .statik(true)
+        .print_system_cflags(false)
+        .print_system_libs(false);
+
+    let mut libdpdk = libdpdk_pkg_config
+        .probe("libdpdk-libs")
+        // This unwrap will result in a compiler error for the user if libdpdk is not found
+        .unwrap();
+
+    libdpdk.libs = libdpdk.libs.into_iter().filter(|lib| !lib.starts_with(':')).collect();
+
 
     let out_dir_s = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_s);
 
-    println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
-    let cflags_bytes = Command::new("pkg-config")
-        .args(&["--cflags", "libdpdk"])
-        .output()
-        .unwrap_or_else(|e| panic!("Failed pkg-config cflags: {:?}", e))
-        .stdout;
-    let cflags = String::from_utf8(cflags_bytes).unwrap();
+    // println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
+    // let cflags_bytes = Command::new("pkg-config")
+    //     .args(&["--cflags", "libdpdk"])
+    //     .output()
+    //     .unwrap_or_else(|e| panic!("Failed pkg-config cflags: {:?}", e))
+    //     .stdout;
+    // let cflags = String::from_utf8(cflags_bytes).unwrap();
 
-    let mut header_locations = vec![];
+    // let mut header_locations = vec![];
 
-    for flag in cflags.split(' ') {
-        if flag.starts_with("-I") {
-            let header_location = flag[2..].trim();
-            header_locations.push(header_location);
-        }
-    }
+    // for flag in cflags.split(' ') {
+    //     if flag.starts_with("-I") {
+    //         let header_location = flag[2..].trim();
+    //         header_locations.push(header_location);
+    //     }
+    // }
 
-    let ldflags_bytes = Command::new("pkg-config")
-        .args(&["--libs", "libdpdk"])
-        .output()
-        .unwrap_or_else(|e| panic!("Failed pkg-config ldflags: {:?}", e))
-        .stdout;
-    let ldflags = String::from_utf8(ldflags_bytes).unwrap();
+    // let ldflags_bytes = Command::new("pkg-config")
+    //     .args(&["--libs", "libdpdk"])
+    //     .output()
+    //     .unwrap_or_else(|e| panic!("Failed pkg-config ldflags: {:?}", e))
+    //     .stdout;
+    // let ldflags = String::from_utf8(ldflags_bytes).unwrap();
 
-    let mut library_location = None;
-    let mut lib_names = vec![];
+    // let mut library_location = None;
+    // let mut lib_names = vec![];
 
-    for flag in ldflags.split(' ') {
-        if flag.starts_with("-L") {
-            library_location = Some(&flag[2..]);
-        } else if flag.starts_with("-l") {
-            lib_names.push(&flag[2..]);
-        }
-    }
+    // for flag in ldflags.split(' ') {
+    //     if flag.starts_with("-L") {
+    //         library_location = Some(&flag[2..]);
+    //     } else if flag.starts_with("-l") {
+    //         lib_names.push(&flag[2..]);
+    //     }
+    // }
 
-    // Link in `librte_net_mlx5` and its dependencies if desired.
-    #[cfg(feature = "mlx5")]
-    {
-        lib_names.extend(&["rte_net_mlx5", "rte_bus_pci", "rte_bus_vdev", "rte_common_mlx5"]);
-    }
+    // // Link in `librte_net_mlx5` and its dependencies if desired.
+    // #[cfg(feature = "mlx5")]
+    // {
+    //     lib_names.extend(&["rte_net_mlx5", "rte_bus_pci", "rte_bus_vdev", "rte_common_mlx5"]);
+    // }
 
-    // Step 1: Now that we've compiled and installed DPDK, point cargo to the libraries.
-    if let Some(location) = library_location {
-        println!("cargo:rustc-link-search=native={}", location);
-    }
+    // // Step 1: Now that we've compiled and installed DPDK, point cargo to the libraries.
+    // if let Some(location) = library_location {
+    //     println!("cargo:rustc-link-search=native={}", location);
+    // }
 
-    for lib_name in &lib_names {
-        println!("cargo:rustc-link-lib=dylib={}", lib_name);
-    }
+    // for lib_name in &lib_names {
+    //     println!("cargo:rustc-link-lib=dylib={}", lib_name);
+    // }
+
+    let include_paths_utf8 = libdpdk.include_paths
+        .iter()
+        .map(|path| match path.to_str() {
+            Some(path) => path,
+            None => {
+                let path_unicode_lossy = path.to_string_lossy();
+                // Panics in build scripts turn into compiler errors. This error should be very rare, but may save
+                // someone a lot of debugging.
+                panic!(
+                    "One of the include paths for libdpdk was not valid UTF-8, the path with all non-UTF-8 characters replaced is: '{}'",
+                    path_unicode_lossy
+                );
+            },
+        })
+        .collect::<Vec<_>>();
 
     // Step 2: Generate bindings for the DPDK headers.
     let mut builder: Builder = Builder::default();
-    for header_location in &header_locations {
+    for header_location in &include_paths_utf8 {
         builder = builder.clang_arg(&format!("-I{}", header_location));
     }
+
     let bindings: Bindings = builder
         .allowlist_recursively(true)
         .allowlist_type("rte_mbuf")
@@ -310,10 +340,12 @@ fn os_build() -> Result<()> {
     builder.pic(true);
     builder.flag("-march=native");
     builder.file("inlined.c");
-    for header_location in &header_locations {
+
+    for header_location in &include_paths_utf8 {
         builder.include(header_location);
     }
     builder.compile("inlined");
+    // panic!("{:#?}", libdpdk);
     Ok(())
 }
 

--- a/build.rs
+++ b/build.rs
@@ -167,73 +167,18 @@ fn os_build() -> Result<()> {
 
 #[cfg(target_os = "linux")]
 fn os_build() -> Result<()> {
-    let mut libdpdk_pkg_config = ::ya_pkg_config::Config::new();
+    let mut libdpdk_pkg_config = ::pkg_config::Config::new();
     libdpdk_pkg_config
-        // .statik(cfg!(static_dpdk))
-        .statik(true)
         .print_system_cflags(false)
         .print_system_libs(false);
 
-    let mut libdpdk = libdpdk_pkg_config
-        .probe("libdpdk-libs")
+    let libdpdk = libdpdk_pkg_config
+        .probe("libdpdk")
         // This unwrap will result in a compiler error for the user if libdpdk is not found
         .unwrap();
 
-    libdpdk.libs = libdpdk.libs.into_iter().filter(|lib| !lib.starts_with(':')).collect();
-
-
     let out_dir_s = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_s);
-
-    // println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
-    // let cflags_bytes = Command::new("pkg-config")
-    //     .args(&["--cflags", "libdpdk"])
-    //     .output()
-    //     .unwrap_or_else(|e| panic!("Failed pkg-config cflags: {:?}", e))
-    //     .stdout;
-    // let cflags = String::from_utf8(cflags_bytes).unwrap();
-
-    // let mut header_locations = vec![];
-
-    // for flag in cflags.split(' ') {
-    //     if flag.starts_with("-I") {
-    //         let header_location = flag[2..].trim();
-    //         header_locations.push(header_location);
-    //     }
-    // }
-
-    // let ldflags_bytes = Command::new("pkg-config")
-    //     .args(&["--libs", "libdpdk"])
-    //     .output()
-    //     .unwrap_or_else(|e| panic!("Failed pkg-config ldflags: {:?}", e))
-    //     .stdout;
-    // let ldflags = String::from_utf8(ldflags_bytes).unwrap();
-
-    // let mut library_location = None;
-    // let mut lib_names = vec![];
-
-    // for flag in ldflags.split(' ') {
-    //     if flag.starts_with("-L") {
-    //         library_location = Some(&flag[2..]);
-    //     } else if flag.starts_with("-l") {
-    //         lib_names.push(&flag[2..]);
-    //     }
-    // }
-
-    // // Link in `librte_net_mlx5` and its dependencies if desired.
-    // #[cfg(feature = "mlx5")]
-    // {
-    //     lib_names.extend(&["rte_net_mlx5", "rte_bus_pci", "rte_bus_vdev", "rte_common_mlx5"]);
-    // }
-
-    // // Step 1: Now that we've compiled and installed DPDK, point cargo to the libraries.
-    // if let Some(location) = library_location {
-    //     println!("cargo:rustc-link-search=native={}", location);
-    // }
-
-    // for lib_name in &lib_names {
-    //     println!("cargo:rustc-link-lib=dylib={}", lib_name);
-    // }
 
     let include_paths_utf8 = libdpdk.include_paths
         .iter()
@@ -250,7 +195,7 @@ fn os_build() -> Result<()> {
             },
         })
         .collect::<Vec<_>>();
-
+ 
     // Step 2: Generate bindings for the DPDK headers.
     let mut builder: Builder = Builder::default();
     for header_location in &include_paths_utf8 {
@@ -345,7 +290,6 @@ fn os_build() -> Result<()> {
         builder.include(header_location);
     }
     builder.compile("inlined");
-    // panic!("{:#?}", libdpdk);
     Ok(())
 }
 


### PR DESCRIPTION
Rust has a pkg-config library that is maintained by the Rust foundation.

Using this instead of the hand-written integration reduces the effort
required to maintain the build system and also adds support for 
cross-compilation (something which is important to many people and
organizations in the DPDK community). This library also handles a few 
edge-cases I ran into with the previous approach involving custom 
configurations of DPDK which link libbsd (a secondary -L argument), or 
statically link mlx5_core into librte_ethdev.